### PR TITLE
Implemented a logger that logs to laravel::info and the database as configured in the .env

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,14 @@
         "northwestern university",
         "laravel"
     ],
-    "authors": [{
+    "authors": [
+        {
         "name": "Nicholas Evans",
-        "email": "nick.evans@northwestern.edu"
-    }],
+        "email": "nick.evans@northwestern.edu" },
+        {
+            "name": "Nate Tracy-Amoroso",
+            "email": "n8@u.northwestern.edu"
+        }],
     "require": {
         "guzzlehttp/guzzle": "^6.3",
         "northwestern-sysdev/event-hub-php-sdk": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "northwestern-sysdev/laravel-soa",
+    "name": "n8ta/laravel-soa",
     "description": "Laravel bindings for popular Northwestern SOA services.",
     "type": "library",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "n8ta/laravel-soa",
+    "name": "northwestern-sysdev/laravel-soa",
     "description": "Laravel bindings for popular Northwestern SOA services.",
     "type": "library",
     "license": "MIT",

--- a/config/nusoa.php
+++ b/config/nusoa.php
@@ -1,6 +1,5 @@
 <?php
 
-
 return [
     'directorySearch' => [
         'baseUrl' => env('DIRECTORY_SEARCH_URL', 'https://northwestern-prod.apigee.net/directory-search'),
@@ -8,6 +7,8 @@ return [
     ],
 
     'sso' => [
+        'db_log_max_entries' => env('sso_log_max_entries','1000000'),
+        'db_log_enabled' => env('sso_db_log_enabled','true'),
         'openAmBaseUrl' => env('WEBSSO_URL_BASE', 'https://websso.it.northwestern.edu'),
     ],
 

--- a/config/nusoa.php
+++ b/config/nusoa.php
@@ -1,5 +1,6 @@
 <?php
 
+
 return [
     'directorySearch' => [
         'baseUrl' => env('DIRECTORY_SEARCH_URL', 'https://northwestern-prod.apigee.net/directory-search'),

--- a/docs/websso.md
+++ b/docs/websso.md
@@ -2,6 +2,7 @@
 The package provides a command that will set up WebSSO, and optionally Duo multi-factor authentication (MFA). 
 
 - Create SSO & Duo controllers in `App\Http\Controllers\Auth`
+- Creates an optional (opt-out) migration/middleware/model to log all accesses to the app
 - Adds named routes to your `web/routes.php`
 - Ejects a `resources/views/auth/mfa.blade.php` template for rendering the Duo MFA widget
 
@@ -111,6 +112,7 @@ class WebSSOController extends Controller
 If you are only using WebSSO to authenticate in your app, this should not be necessary. If you have multiple login methods, you will either need to rename the routes, or update your `App\Http\Middleware\Authenticate` to send unauthenticated users to page that lets them choose their login method.
 
 ## API
+
 The webSSO class will resolve the value of an `openAMssoToken` cookie into a NetID.
 
 :::tip Unusual Use-cases Only
@@ -142,3 +144,20 @@ class MyController extends Controller
     }
 }
 ```
+
+## Access Logging
+
+All requests your app receives will by default be logged to the database and to the default laravel logger in a splunk compatible format. 
+
+To disable the database logger add the following to your .env
+
+```env
+SSO_DB_LOG_ENABLED=false
+```
+
+To increase or decrease the number of logs to store add SSO_LOG_MAX_ENTRIES  to your .env. The default value is 1,000,000 which takes up about 36MB (tested on mysql). 
+
+````
+SSO_LOG_MAX_ENTRIES=1000000
+````
+

--- a/docs/websso.md
+++ b/docs/websso.md
@@ -54,6 +54,13 @@ protected function findUserByNetID(string $netid): ?Authenticatable
 
 You may optionally implement the `authenticated` method. If you return a `redirect()`, it will be followed. Otherwise, the default Laravel behaviour will be used.
 
+Then add the ```auth``` middleware to whatever routes you want to be protected by SSO. For example:
+
+```php
+Route::get('/', 'NuOnlyController@private')->middleware('auth')  ;
+Route::get('/pub', 'PublicatController@public_route');
+```
+
 ## Enabling Duo MFA
 If you want to enable Duo MFA, you will need to submit a ticket to Identity Services team via [consultant@northwestern.edu](mailto:consultant@northwestern.edu):
 
@@ -117,7 +124,7 @@ namespace App\Http\Controllers;
 
 use Northwestern\SysDev\SOA\WebSSO;
 
-class MyController extends Controllers
+class MyController extends Controller
 {
     public function login(Request $request, WebSSO $sso)
     {

--- a/docs/websso.md
+++ b/docs/websso.md
@@ -58,7 +58,7 @@ Then add the ```auth``` middleware to whatever routes you want to be protected b
 
 ```php
 Route::get('/', 'NuOnlyController@private')->middleware('auth')  ;
-Route::get('/pub', 'PublicatController@public_route');
+Route::get('/pub', 'PublicController@public_route');
 ```
 
 ## Enabling Duo MFA

--- a/src/Auth/SSOLoggable.php
+++ b/src/Auth/SSOLoggable.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Northwestern\SysDev\SOA\Auth;
+
+trait SSOLoggable
+{
+    public function identifiers()
+    {
+        return '';
+
+        # If you have the netid attribute you might replace this method with:
+        # return 'netid='.$this->netid
+
+        # Or if you want to pass multiple identifiers:
+        # return 'netid='.$this->netid.' firstname='.$this->name.' lastname='.$this->lastname
+        # => "netid=jmm222 firstname=Jimmy lastname=McMillan"
+    }
+}

--- a/src/Console/Commands/MakeLog.php
+++ b/src/Console/Commands/MakeLog.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Northwestern\SysDev\SOA\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Facades\Artisan;
+
+class MakeLog extends GeneratorCommand
+{
+    protected $name = "make:log";
+    protected $signature = 'make:log';
+    protected $description = 'Creates a database migration for an access log';
+    protected $type = 'Migration';
+
+    public function handle()
+    {
+        parent::handle();
+    }
+
+    protected function getStub()
+    {
+        return __DIR__ . '/../../../stubs/2019_10_18_0000000_create_access_log_table.stub';
+    }
+
+    protected function getNameInput()
+    {
+        return '2019_10_18_0000000_create_access_log';
+    }
+
+    protected function getDefaultNamespace($rootNamespace)
+    {
+
+        return $rootNamespace.'\..\database\migrations';
+    }
+
+}

--- a/src/Console/Commands/MakeSsoLogMigration.php
+++ b/src/Console/Commands/MakeSsoLogMigration.php
@@ -13,7 +13,6 @@ class MakeSsoLogMigration extends GeneratorCommand
 
     public function handle()
     {
-        print("Add SSO_LOG_ENABLED=false to turn off request logging \n");
         parent::handle();
     }
 

--- a/src/Console/Commands/MakeSsoLogMigration.php
+++ b/src/Console/Commands/MakeSsoLogMigration.php
@@ -3,17 +3,17 @@
 namespace Northwestern\SysDev\SOA\Console\Commands;
 
 use Illuminate\Console\GeneratorCommand;
-use Illuminate\Support\Facades\Artisan;
 
-class MakeLog extends GeneratorCommand
+class MakeSsoLogMigration extends GeneratorCommand
 {
-    protected $name = "make:log";
-    protected $signature = 'make:log';
+    protected $name = "make:log_migration";
+    protected $signature = 'make:log_migration';
     protected $description = 'Creates a database migration for an access log';
     protected $type = 'Migration';
 
     public function handle()
     {
+        print("Add SSO_LOG_ENABLED=true to your env variables to enable logging \n");
         parent::handle();
     }
 
@@ -32,5 +32,4 @@ class MakeLog extends GeneratorCommand
 
         return $rootNamespace.'\..\database\migrations';
     }
-
 }

--- a/src/Console/Commands/MakeSsoLogMigration.php
+++ b/src/Console/Commands/MakeSsoLogMigration.php
@@ -13,7 +13,7 @@ class MakeSsoLogMigration extends GeneratorCommand
 
     public function handle()
     {
-        print("Add SSO_LOG_ENABLED=true to your env variables to enable logging \n");
+        print("Add SSO_LOG_ENABLED=false to turn off request logging \n");
         parent::handle();
     }
 

--- a/src/Console/Commands/MakeSsoLogModel.php
+++ b/src/Console/Commands/MakeSsoLogModel.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Northwestern\SysDev\SOA\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+
+class MakeSsoLogModel extends GeneratorCommand
+{
+    protected $name = "make:log_model";
+    protected $signature = 'make:log_model';
+    protected $description = 'Creates a model for the access log table';
+    protected $type = 'Model';
+
+    public function handle()
+    {
+        parent::handle();
+    }
+
+    protected function getStub()
+    {
+        return __DIR__ . '/../../../stubs/Access.stub';
+    }
+
+    protected function getNameInput()
+    {
+        return 'Access';
+    }
+
+    protected function getDefaultNamespace($rootNamespace)
+    {
+
+        return $rootNamespace;
+    }
+}

--- a/src/Console/Commands/MakeWebSSO.php
+++ b/src/Console/Commands/MakeWebSSO.php
@@ -21,9 +21,10 @@ class MakeWebSSO extends GeneratorCommand
 
         // Generate the migration unless they have it explicitly turned off in the .env, we default to DB logging + file logging.
         print("Add SSO_DB_LOG_ENABLED=false to your .env turn off database request logging \n");
-        if (env('SSO_DB_LOG_ENABLED','true') != 'false') {
+        if (env('SSO_DB_LOG_ENABLED',true) != false) {
             Artisan::call(MakeSsoLogMigration::class);
             Artisan::call(MakeSsoLogModel::class);
+        } else {
         }
         $this->ejectRoutes();
     }

--- a/src/Console/Commands/MakeWebSSO.php
+++ b/src/Console/Commands/MakeWebSSO.php
@@ -21,7 +21,7 @@ class MakeWebSSO extends GeneratorCommand
 
         // Generate the migration unless they have it explicitly turned off in the .env, we default to DB logging + file logging.
         print("Add SSO_DB_LOG_ENABLED=false to your .env turn off database request logging \n");
-        if (env('SSO_DB_LOG_ENABLED',true) != false) {
+        if (config('sso_db_log_enabled') != false) {
             Artisan::call(MakeSsoLogMigration::class);
             Artisan::call(MakeSsoLogModel::class);
         } else {

--- a/src/Console/Commands/MakeWebSSO.php
+++ b/src/Console/Commands/MakeWebSSO.php
@@ -19,7 +19,7 @@ class MakeWebSSO extends GeneratorCommand
         // is an expedient way of writing this cleanly!
         Artisan::call(MakeDuo::class);
         Artisan::call(MakeSsoLogMigration::class);
-        Artisan::call(MakeSsoLogMiddleware::class);
+        Artisan::call(MakeSsoLogModel::class);
 
         $this->ejectRoutes();
     }

--- a/src/Console/Commands/MakeWebSSO.php
+++ b/src/Console/Commands/MakeWebSSO.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Artisan;
 class MakeWebSSO extends GeneratorCommand
 {
     protected $signature = 'make:websso';
-    protected $description = 'Create a new Northwestern WebSSO controller';
+    protected $description = 'Create a new Northwestern WebSSO controller and sets up an access log  migration/model';
     protected $type = 'Controller';
 
     public function handle()
@@ -18,9 +18,13 @@ class MakeWebSSO extends GeneratorCommand
         // GeneratorCommand only does one stub at a time, but I want both, so chaining these
         // is an expedient way of writing this cleanly!
         Artisan::call(MakeDuo::class);
-        Artisan::call(MakeSsoLogMigration::class);
-        Artisan::call(MakeSsoLogModel::class);
 
+        // Generate the migration unless they have it explicitly turned off in the .env, we default to DB logging + file logging.
+        print("Add SSO_DB_LOG_ENABLED=false to your .env turn off database request logging \n");
+        if (env('SSO_DB_LOG_ENABLED','true') != 'false') {
+            Artisan::call(MakeSsoLogMigration::class);
+            Artisan::call(MakeSsoLogModel::class);
+        }
         $this->ejectRoutes();
     }
 

--- a/src/Console/Commands/MakeWebSSO.php
+++ b/src/Console/Commands/MakeWebSSO.php
@@ -18,6 +18,8 @@ class MakeWebSSO extends GeneratorCommand
         // GeneratorCommand only does one stub at a time, but I want both, so chaining these
         // is an expedient way of writing this cleanly!
         Artisan::call(MakeDuo::class);
+        Artisan::call(MakeSsoLogMigration::class);
+        Artisan::call(MakeSsoLogMiddleware::class);
 
         $this->ejectRoutes();
     }

--- a/src/Http/Middleware/SsoLogger.php
+++ b/src/Http/Middleware/SsoLogger.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Northwestern\SysDev\SOA\Http\Middleware;
+
+use http\Env;
+use Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode as Middleware;
+use Auth;
+use Closure;
+
+class SsoLogger extends Middleware
+{
+
+    public function handle($request, Closure $next, ...$guards)
+    {
+        if (env('SSO_LOG_ENABLED') != 'true') { return $next($request); }
+
+        $controller = $request->route()->controller;
+
+        if (class_basename($controller) == "WebSSOController") {
+            // They're doing auth right now so minimal log
+            $this->log_request(true, $request);
+            return $next($request);
+        } else {
+            if (Auth()->user() == null) {
+                $this->log_request(true, $request);
+            } else {
+                $this->log_request(false, $request);
+            }
+        }
+        return $next($request);
+    }
+
+    private function log_request($anonymous, $request) {
+        if ($this->should_be_logged($request)) {
+
+        }
+        return;
+
+    }
+
+    public function should_be_logged($request) {
+        return True;
+    }
+
+}

--- a/src/Http/Middleware/SsoLogger.php
+++ b/src/Http/Middleware/SsoLogger.php
@@ -16,7 +16,7 @@ class SsoLogger extends Middleware
 
     public function handle($request, Closure $next, ...$guards)
     {
-        if (env('SSO_LOG_ENABLED') != 'true') { return $next($request); }
+        if (env('SSO_LOG_ENABLED','true') != 'true') { return $next($request); }
 
         $controller = $request->route()->controller;
 
@@ -59,7 +59,7 @@ class SsoLogger extends Middleware
     private function remove_oldest_logs() {
         // Remove between 1000 and 5000 logs at a time. Scaled roughly by max logs set.
         // I don't want to remove more than 5000 and risk slowing down the request significantly.
-        $num_to_remove = max(min(5000,$this->max_logs/10),1000);
+        $num_to_remove = max(min(5,$this->max_logs/10),1);
         Access::orderBy('created_at','asc')->take($num_to_remove)->get()->each->delete();
         # ^ Probably a better way to do this than individual deletes
     }

--- a/src/Http/Middleware/SsoLogger.php
+++ b/src/Http/Middleware/SsoLogger.php
@@ -32,7 +32,13 @@ class SsoLogger extends Middleware
 
     private function log_request($anonymous, $request) {
         $path = $request->path();
-        $agent = $request->header('User-Agent');
+
+        try {
+            $agent = $request->header('User-Agent');
+        }  catch (Exception $x) {
+            $agent = null;
+        }
+
         $access = new \App\Access(['path'=>$path,'agent'=>$agent]);
         if (!$anonymous) {
             $access->netid = Auth::user()['netid'];

--- a/src/Http/Middleware/SsoLogger.php
+++ b/src/Http/Middleware/SsoLogger.php
@@ -2,70 +2,74 @@
 
 namespace Northwestern\SysDev\SOA\Http\Middleware;
 
-use http\ENV;
-use Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode as Middleware;
-use Auth;
 use App\Access;
+use Auth;
 use Closure;
+use http\Exception;
+use http\Exception\RuntimeException;
+use Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode as Middleware;
 use Illuminate\Support\Facades\Log;
+use Northwestern\SysDev\SOA\Auth\SSOLoggable;
 
 class SsoLogger extends Middleware
 {
     protected $max_logs;
 
-    public function __construct() { $this->max_logs = ENV('SSO_LOG_MAX_ENTRIES',1000000); }
+    public function __construct()
+    {
+        $this->max_logs = config('nusoa.sso.db_log_max_entries');
+    }
 
     public function handle($request, Closure $next, ...$guards)
     {
-        $controller = $request->route()->controller;
-
-        if (class_basename($controller) == "WebSSOController") {
-            // They're doing auth right now so we'll call it an anonymous request (no netid)
-            $this->log_request(true, $request);
-            return $next($request);
+        $user = Auth::user();
+        if ($user == null) {
+            $this->log_request($request);
         } else {
-            if (Auth()->user() == null) {
-                $this->log_request(true, $request);
-            } else {
-                $this->log_request(false, $request);
-            }
+            $this->log_request($request, $user);
         }
-
-
-        if (sizeof(Access::all()) > $this->max_logs) {
+        if (Access::count() > $this->max_logs) {
             $this->remove_oldest_logs();
         };
-
         return $next($request);
     }
 
-    private function log_request($anonymous, $request) {
+    private function log_request($request,  $user=NULL)
+    {
+
+        if (($user != NULL) && (!in_array('Northwestern\SysDev\SOA\Auth\SSOLoggable',class_uses($user)))) {
+            dd('You must implement the Northwestern\SysDev\SOA\Auth\SSOLoggable trait on your user 
+            model for sso logging to work. See the documentation for setup instructions.');
+        }
+
         $path = $request->path();
+
         try {
             $agent = $request->header('User-Agent');
-        }  catch (Exception $x) {
-            $agent = null;
+        } catch (Exception $x) {
+            $agent = 'null';
         }
-        $access = new Access(['path'=>$path,'agent'=>$agent]);
+
+        $access = new Access(['path' => $path, 'agent' => $agent]);
         $time = Time();
-        if (!$anonymous) {
-            $netid = Auth::user()['netid'];
-            Log::info("Access netid=$netid agent=$agent path=$path time=$time");
-            $access->netid = $netid;
-        } else {
-            Log::info("Access netid=NULL agent=$agent path=$path time=$time");
+
+        if ($user != null) {
+            $access->primary_user_id = $user->getAuthIdentifier();
+            $identifier = $user->identifiers();
+            Log::info("Access $identifier agent=$agent path=$path time=$time");
         }
-        if (env('SSO_DB_LOG_ENABLED','true') == 'true') {
+
+        if (config('nusoa.sso.db_log_enabled') == 'true') {
             $access->save();
         }
         return;
     }
 
-    private function remove_oldest_logs() {
+    private function remove_oldest_logs()
+    {
         // Remove between 1000 and 5000 logs at a time. Scaled roughly by max logs set.
         // I don't want to remove more than 5000 and risk slowing down the request significantly.
-        $num_to_remove = max(min(5,$this->max_logs/10),1);
-        Access::orderBy('created_at','asc')->take($num_to_remove)->get()->each->delete();
-        # ^ Probably a better way to do this than individual deletes
+        $num_to_remove = max(min(5, $this->max_logs / 10), 1);
+        Access::orderBy('created_at', 'asc')->take($num_to_remove)->delete();
     }
 }

--- a/src/Http/Middleware/SsoLogger.php
+++ b/src/Http/Middleware/SsoLogger.php
@@ -20,7 +20,7 @@ class SsoLogger extends Middleware
         $controller = $request->route()->controller;
 
         if (class_basename($controller) == "WebSSOController") {
-            // They're doing auth right now so minimal log
+            // They're doing auth right now so we'll call it an anonymous request (no netid)
             $this->log_request(true, $request);
             return $next($request);
         } else {

--- a/src/Http/Middleware/SsoLogger.php
+++ b/src/Http/Middleware/SsoLogger.php
@@ -2,13 +2,17 @@
 
 namespace Northwestern\SysDev\SOA\Http\Middleware;
 
-use http\Env;
+use http\ENV;
 use Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode as Middleware;
 use Auth;
+use App\Access;
 use Closure;
 
 class SsoLogger extends Middleware
 {
+    protected $max_logs;
+
+    public function __construct() { $this->max_logs = ENV('SSO_LOG_MAX_ENTRIES',1000000); }
 
     public function handle($request, Closure $next, ...$guards)
     {
@@ -27,23 +31,36 @@ class SsoLogger extends Middleware
                 $this->log_request(false, $request);
             }
         }
+
+
+        if (sizeof(Access::all()) > $this->max_logs) {
+            $this->remove_oldest_logs();
+        };
+
         return $next($request);
     }
 
     private function log_request($anonymous, $request) {
         $path = $request->path();
-
         try {
             $agent = $request->header('User-Agent');
         }  catch (Exception $x) {
             $agent = null;
         }
 
-        $access = new \App\Access(['path'=>$path,'agent'=>$agent]);
+        $access = new Access(['path'=>$path,'agent'=>$agent]);
         if (!$anonymous) {
             $access->netid = Auth::user()['netid'];
         }
         $access->save();
         return;
+    }
+
+    private function remove_oldest_logs() {
+        // Remove between 1000 and 5000 logs at a time. Scaled roughly by max logs set.
+        // I don't want to remove more than 5000 and risk slowing down the request significantly.
+        $num_to_remove = max(min(5000,$this->max_logs/10),1000);
+        Access::orderBy('created_at','asc')->take($num_to_remove)->get()->each->delete();
+        # ^ Probably a better way to do this than individual deletes
     }
 }

--- a/src/Http/Middleware/SsoLogger.php
+++ b/src/Http/Middleware/SsoLogger.php
@@ -31,15 +31,13 @@ class SsoLogger extends Middleware
     }
 
     private function log_request($anonymous, $request) {
-        if ($this->should_be_logged($request)) {
-
+        $path = $request->path();
+        $agent = $request->header('User-Agent');
+        $access = new \App\Access(['path'=>$path,'agent'=>$agent]);
+        if (!$anonymous) {
+            $access->netid = Auth::user()['netid'];
         }
+        $access->save();
         return;
-
     }
-
-    public function should_be_logged($request) {
-        return True;
-    }
-
 }

--- a/src/Models/Access.php
+++ b/src/Models/Access.php
@@ -1,10 +1,13 @@
 <?php
 
-namespace App;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
 class Access extends Model
 {
-    //
+    public function dye() {
+        dd('test');
+    }
+
 }

--- a/src/Models/Access.php
+++ b/src/Models/Access.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Access extends Model
+{
+    //
+}

--- a/src/Providers/NuSoaServiceProvider.php
+++ b/src/Providers/NuSoaServiceProvider.php
@@ -27,9 +27,6 @@ class NuSoaServiceProvider extends ServiceProvider
             __DIR__ . '/../../config/duo.php' => config_path('duo.php'),
         ], 'config');
 
-        $this->publishes([
-            __DIR__ . '/../Models' => model_path(),
-        ], 'models');
 
         if ($this->app->runningInConsole()) {
             $this->commands([
@@ -40,6 +37,7 @@ class NuSoaServiceProvider extends ServiceProvider
                 Commands\EventHub\WebhookConfiguration::class,
                 Commands\MakeWebSSO::class,
                 Commands\MakeSsoLogMigration::class,
+                Commands\MakeSsoLogModel::class,
                 Commands\MakeDuo::class,
             ]);
         }

--- a/src/Providers/NuSoaServiceProvider.php
+++ b/src/Providers/NuSoaServiceProvider.php
@@ -35,6 +35,7 @@ class NuSoaServiceProvider extends ServiceProvider
 
                 Commands\MakeWebSSO::class,
                 Commands\MakeDuo::class,
+                Commands\MakeLog::class,
             ]);
         }
 

--- a/stubs/2019_10_18_0000000_create_access_log_table.stub
+++ b/stubs/2019_10_18_0000000_create_access_log_table.stub
@@ -16,7 +16,7 @@ class CreateAccessLog extends Migration
     {
         Schema::create('accesses', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('netid')->nullable()->default(null);
+            $table->string('primary_user_id')->nullable()->default(null);
             $table->string('path');
             $table->string('agent');
             $table->timestamp('created_at')->useCurrent();

--- a/stubs/2019_10_18_0000000_create_access_log_table.stub
+++ b/stubs/2019_10_18_0000000_create_access_log_table.stub
@@ -1,0 +1,35 @@
+
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateAccessLog extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('accesses', function (Blueprint $table) {
+            $table->string('netid');
+            $table->integer('id');
+            $table->string('path');
+            $table->string('agent');
+            $table->timestamp('time');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('accesses');
+    }
+}

--- a/stubs/2019_10_18_0000000_create_access_log_table.stub
+++ b/stubs/2019_10_18_0000000_create_access_log_table.stub
@@ -15,11 +15,11 @@ class CreateAccessLog extends Migration
     public function up()
     {
         Schema::create('accesses', function (Blueprint $table) {
-            $table->string('netid');
-            $table->integer('id');
+            $table->bigIncrements('id');
+            $table->string('netid')->nullable()->default(null);
             $table->string('path');
             $table->string('agent');
-            $table->timestamp('time');
+            $table->timestamp('created_at')->useCurrent();
         });
     }
 

--- a/stubs/Access.stub
+++ b/stubs/Access.stub
@@ -4,9 +4,12 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 
-class access extends Model
+class Access extends Model
 {
+    public $timestamps = false;
+
     protected $fillable = [
-        'netid', 'id', 'agent', 'path', 'time'
+        'netid', 'agent', 'path', 'created_at'
     ];
+
 }

--- a/stubs/Access.stub
+++ b/stubs/Access.stub
@@ -1,0 +1,9 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class access extends Model
+{
+}

--- a/stubs/Access.stub
+++ b/stubs/Access.stub
@@ -6,4 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class access extends Model
 {
+    protected $fillable = [
+        'netid', 'id', 'agent', 'path', 'time'
+    ];
 }


### PR DESCRIPTION
This defaults to logging to the database by publishing a migration and providing a middleware. You can disable both of these in your .env as described  in the docs. 

Also when I set this up the first time I didn't realize right away that I needed to call the auth middleware to get SSO to run so I think that's probably worth including in the docs as well. This also fixes a typo in the example controller.