### PR TITLE
Throw exceptions for common SSO configuration issues

### DIFF
--- a/docs/websso.md
+++ b/docs/websso.md
@@ -15,9 +15,9 @@ The package does not implement a custom [auth provider](https://laravel.com/docs
 :::
 
 ## Prerequisites
-You will need an Apigee key with access to the `IDM - Agentless WebSSO`. The key will include access to the SSO & MFA API. 
+You will need an Apigee key with access to the `IDM - Agentless WebSSO`. The key will include access to the SSO & MFA API. This must be requested through the [API service registry](https://apiserviceregistry.northwestern.edu/). 
 
-This must be requested through the [API service registry](https://apiserviceregistry.northwestern.edu/).
+Your application must be served over HTTPS on a `northwestern.edu` domain. The SSO cookie (`nusso`) is flagged as Secure=true; there is no way for Laravel to access the cookie when served over an insecure http connection.
 
 ## Setting up SSO
 Getting webSSO working should only take a few minutes.

--- a/src/Auth/Strategy/OpenAM11.php
+++ b/src/Auth/Strategy/OpenAM11.php
@@ -3,6 +3,7 @@
 namespace Northwestern\SysDev\SOA\Auth\Strategy;
 
 use Illuminate\Http\Request;
+use Northwestern\SysDev\SOA\Exceptions\InsecureSsoError;
 use Northwestern\SysDev\SOA\WebSSO;
 
 /**
@@ -19,6 +20,10 @@ class OpenAM11 implements WebSSOStrategy
 
     public function login(Request $request, string $login_route_name)
     {
+        if (! $request->isSecure()) {
+            throw new InsecureSsoError;
+        }
+
         $login_url_w_redirect = $this->sso->getLoginUrl(route($login_route_name, [], false));
 
         // Laravel nulls out cookies that are not encrypted w/ its key.

--- a/src/Exceptions/ApigeeAuthenticationError.php
+++ b/src/Exceptions/ApigeeAuthenticationError.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Northwestern\SysDev\SOA\Exceptions;
+
+class ApigeeAuthenticationError extends \Exception
+{
+    public function __construct(string $apigeeEndpoint)
+    {
+        parent::__construct(sprintf('The configured Apigee API key (WEBSSO_API_KEY) is invalid for %s', $apigeeEndpoint));
+    }
+}

--- a/src/Exceptions/InsecureSsoError.php
+++ b/src/Exceptions/InsecureSsoError.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Northwestern\SysDev\SOA\Exceptions;
+
+class InsecureSsoError extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct('The webSSO connection is insecure (http://). The SSO cookie is only available on a secure (https://) connection.');
+    }
+}

--- a/tests/Exceptions/ApigeeAuthenticationErrorTest.php
+++ b/tests/Exceptions/ApigeeAuthenticationErrorTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Northwestern\SysDev\SOA\Tests\Exceptions;
+
+use Northwestern\SysDev\SOA\Exceptions\ApigeeAuthenticationError;
+use Orchestra\Testbench\TestCase;
+
+class ApigeeAuthenticationErrorTest extends TestCase
+{
+    /** @test */
+    public function throwable()
+    {
+        $this->expectExceptionMessageMatches('/WEBSSO_API_KEY/i');
+
+        throw new ApigeeAuthenticationError('https://apigee.example.org');
+    }
+}

--- a/tests/Exceptions/InsecureSsoErrorTest.php
+++ b/tests/Exceptions/InsecureSsoErrorTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Northwestern\SysDev\SOA\Tests\Exceptions;
+
+use Northwestern\SysDev\SOA\Exceptions\InsecureSsoError;
+use Orchestra\Testbench\TestCase;
+
+class InsecureSsoErrorTest extends TestCase
+{
+    /** @test */
+    public function throwable()
+    {
+        $this->expectExceptionMessageMatches('/https/');
+
+        throw new InsecureSsoError;
+    }
+}

--- a/tests/WebSSO/OpenAM11Test.php
+++ b/tests/WebSSO/OpenAM11Test.php
@@ -3,6 +3,7 @@
 namespace Northwestern\SysDev\SOA\Tests\WebSSO;
 
 use GuzzleHttp\Client;
+use Northwestern\SysDev\SOA\Exceptions\ApigeeAuthenticationError;
 use Northwestern\SysDev\SOA\WebSSO;
 use Northwestern\SysDev\SOA\Tests\TestCase;
 use Northwestern\SysDev\SOA\Tests\Concerns\TestsOpenAM11;
@@ -41,10 +42,20 @@ class OpenAM11Test extends TestCase
     /** @test */
     public function invalid_session()
     {
-        $this->api->setHttpClient($this->mockedResponse(401, ''));
+        $this->api->setHttpClient($this->mockedResponse(407, ''));
 
         $user = $this->api->getUser('test-token');
         $this->assertNull($user);
+    }
+
+    /** @test */
+    public function invalid_apigee_key()
+    {
+        $this->expectException(ApigeeAuthenticationError::class);
+
+        $this->api->setHttpClient($this->mockedResponse(401, ''));
+
+        $this->api->getUser('test-token');
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds two developer experience enhancements:

- When Apigee indicates an API key is invalid, `ApigeeAuthenticationError` is thrown explaining what env var is wrong.
- When attempting to do SSO over an insecure connection, `InsecureSsoError` is thrown explaining that https must be used.

Detecting and throwing exceptions in these cases eliminate the dreaded infinite redirect loop between your app and the SSO page.