### PR TITLE
Oauth2 scopes & tokens

### DIFF
--- a/src/Auth/Entity/ActiveDirectoryUser.php
+++ b/src/Auth/Entity/ActiveDirectoryUser.php
@@ -6,6 +6,9 @@ use Illuminate\Support\Arr;
 
 class ActiveDirectoryUser implements OAuthUser
 {
+    /** @var string JWT for Microsoft APIs */
+    protected $token;
+
     /** @var string */
     protected $netid;
 
@@ -27,8 +30,9 @@ class ActiveDirectoryUser implements OAuthUser
     /** @var array */
     protected $rawData;
 
-    public function __construct(array $rawData)
+    public function __construct(string $token, array $rawData)
     {
+        $this->token = $token;
         $this->rawData = $rawData;
 
         $this->netid = strtolower(explode('@', Arr::get($this->rawData, 'userPrincipalName'))[0]);
@@ -37,6 +41,16 @@ class ActiveDirectoryUser implements OAuthUser
         $this->displayName = Arr::get($this->rawData, 'displayName');
         $this->firstName = Arr::get($this->rawData, 'givenName');
         $this->lastName = Arr::get($this->rawData, 'surname');
+    }
+
+    /**
+     * JWT for accessing Microsoft APIs.
+     *
+     * @return string
+     */
+    public function getToken()
+    {
+        return $this->token;
     }
 
     /**

--- a/src/Auth/Entity/OAuthUser.php
+++ b/src/Auth/Entity/OAuthUser.php
@@ -4,6 +4,7 @@ namespace Northwestern\SysDev\SOA\Auth\Entity;
 
 interface OAuthUser
 {
+    public function getToken();
     public function getNetid();
     public function getEmail();
     public function getDisplayName();

--- a/src/Auth/OAuth2/MicrosoftGraphError.php
+++ b/src/Auth/OAuth2/MicrosoftGraphError.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Northwestern\SysDev\SOA\Auth\OAuth2;
+
+use \Exception;
+use GuzzleHttp\Exception\ClientException;
+
+/**
+ * Unpacks the Microsoft Graph API response JSON into the full message.
+ *
+ * These errors would typically be truncated in a logger since the response body is
+ * cut off after X characters. This exception wraps a Guzzle error and exposes the full
+ * JSON response as the error message instead of truncating it.
+ */
+class MicrosoftGraphError extends Exception
+{
+    public function __construct(ClientException $previous)
+    {
+        parent::__construct($previous->getResponse()->getBody()->getContents(), $previous->getCode(), $previous);
+    }
+}

--- a/src/Auth/OAuth2/NorthwesternAzureProvider.php
+++ b/src/Auth/OAuth2/NorthwesternAzureProvider.php
@@ -2,6 +2,7 @@
 
 namespace Northwestern\SysDev\SOA\Auth\OAuth2;
 
+use GuzzleHttp\Exception\ClientException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Str;
@@ -25,8 +26,10 @@ class NorthwesternAzureProvider extends AbstractProvider
      */
     protected $graphUrl = 'https://graph.microsoft.com/v1.0/me/';
 
-    /** @var string Scopes to request */
+    /** @var string Default scopes to request */
     protected $scopes = ['openid'];
+    protected $scopeSeparator = ' ';
+
 
     /**
      * {@inheritDoc}
@@ -127,12 +130,16 @@ class NorthwesternAzureProvider extends AbstractProvider
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get($this->graphUrl, [
-            'headers' => [
-                'Accept'        => 'application/json',
-                'Authorization' => 'Bearer '.$token,
-            ],
-        ]);
+        try {
+            $response = $this->getHttpClient()->get($this->graphUrl, [
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'Authorization' => 'Bearer ' . $token,
+                ],
+            ]);
+        } catch (ClientException $e) {
+            throw new MicrosoftGraphError($e);
+        }
 
         return json_decode($response->getBody()->getContents(), true);
     }

--- a/src/Auth/WebSSOAuthentication.php
+++ b/src/Auth/WebSSOAuthentication.php
@@ -82,7 +82,7 @@ trait WebSSOAuthentication
             throw $e;
         }
 
-        $oauthUser = new ActiveDirectoryUser($userInfo->getRaw());
+        $oauthUser = new ActiveDirectoryUser($userInfo->token, $userInfo->getRaw());
 
         $user = app()->call(
             \Closure::fromCallable('static::findUserByOAuthUser'),
@@ -143,12 +143,22 @@ trait WebSSOAuthentication
      */
     protected function oauthDriver()
     {
-        $driver = Socialite::driver('northwestern-azure');
+        $driver = Socialite::driver('northwestern-azure')->scopes($this->oauthScopes());
 
         if (! config('services.azure.redirect')) {
             $driver = $driver->redirectUrl(route($this->oauth_callback_route_name, [], true));
         }
 
         return $driver;
+    }
+
+    /**
+     * Additional scopes for the user.
+     *
+     * @return array
+     */
+    protected function oauthScopes()
+    {
+        return ['https://graph.microsoft.com/User.Read'];
     }
 }

--- a/stubs/WebSSOController.stub
+++ b/stubs/WebSSOController.stub
@@ -32,6 +32,9 @@ class WebSSOController extends Controller
 
         // If you don't implement this method, it'll be bypassed and the netID from the
         // OAuth user is given to ::findUserByNetID.
+
+        // If you plan on doing integrations with Microsoft, you should make your calls with
+        // $oauthUser->token now, or record it somewhere for later API calls.
     }
     */
 

--- a/stubs/WebSSOController.stub
+++ b/stubs/WebSSOController.stub
@@ -39,6 +39,16 @@ class WebSSOController extends Controller
     */
 
     /*
+    protected function oauthScopes()
+    {
+        // You can request consent to additional scopes by adding them to this method.
+        // They can be scopes for other registered apps, or Microsoft's scopes for their various APIs.
+
+        return ['https://graph.microsoft.com/User.Read'];
+    }
+    */
+
+    /*
     protected function authenticated(Request $request, $user)
     {
         // Post-authentication hook. You are not required to implement anything here.

--- a/tests/Auth/Entity/ActiveDirectoryUserTest.php
+++ b/tests/Auth/Entity/ActiveDirectoryUserTest.php
@@ -9,7 +9,7 @@ class ActiveDirectoryUserTest extends TestCase
 {
     public function testEntity()
     {
-        $user = new ActiveDirectoryUser([
+        $user = new ActiveDirectoryUser('abcdefg', [
             'mailNickname' => 'TEST123',
             'mail' => 'foo@bar.net',
             'userPrincipalName' => 'TEST123@foo.bar.net',
@@ -18,6 +18,7 @@ class ActiveDirectoryUserTest extends TestCase
             'surname' => 'Bar',
         ]);
 
+        $this->assertEquals('abcdefg', $user->getToken());
         $this->assertEquals('test123', $user->getNetid());
         $this->assertEquals('foo@bar.net', $user->getEmail());
         $this->assertEquals('TEST123@foo.bar.net', $user->getUserPrincipalName());

--- a/tests/Auth/OAuthAuthenticationTest.php
+++ b/tests/Auth/OAuthAuthenticationTest.php
@@ -35,6 +35,7 @@ class OAuthAuthenticationTest extends TestCase
     {
         $this->app['router']->get(__METHOD__, function (Request $request) {
             $oauthUser = $this->createStub(User::class);
+            $oauthUser->token = 'a';
             $oauthUser->method('getRaw')->willReturn([
                 'mailNickname' => 'foo',
             ]);
@@ -46,6 +47,7 @@ class OAuthAuthenticationTest extends TestCase
         });
 
         $response = $this->get(__METHOD__);
+        dump($response->exception);
         $response->assertRedirect('/logged-in');
         $this->assertAuthenticated();
     }


### PR DESCRIPTION
Based on initial user testing (outside of IT), I noticed two issues:

- We're not getting the Read.All scope for the Graph API. I think I must have implicitly consented to this at some point, but the first time we had an OUR person try to log in to competitive-apps, we got a permission error.
- The Graph API failures don't log the whole error because guzzle lol

I've added a way for users of the library to add scopes and defaulted to the User.Read scope for the graph API.

When fixing this, I made a change to the OAuth2 user interface we're passing back to the user's code. This change exposes the JWT so they can use it for their own subsequent API calls.