### PR TITLE
PHP 8.4 Compatibility

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3']
+        php-versions: ['8.2', '8.3', '8.4']
 
     steps:
     - uses: actions/checkout@v4

--- a/tests/Feature/Auth/OAuthAuthenticationTest.php
+++ b/tests/Feature/Auth/OAuthAuthenticationTest.php
@@ -24,17 +24,17 @@ final class OAuthAuthenticationTest extends TestCase
 
     public function test_redirects_to_oauth_provider(): void
     {
-        $this->app['router']->get(__METHOD__, function (Request $request) {
+        $this->app['router']->get(__FUNCTION__, function (Request $request) {
             return $this->mock_controller()->oauthRedirect($request);
         });
 
-        $response = $this->get(__METHOD__);
+        $response = $this->get(__FUNCTION__);
         $response->assertRedirect(self::OAUTH_DUMMY_PROVIDER_URL);
     }
 
     public function test_callback_success(): void
     {
-        $this->app['router']->get(__METHOD__, function (Request $request) {
+        $this->app['router']->get(__FUNCTION__, function (Request $request) {
             $oauthUser = $this->createStub(User::class);
             $oauthUser->token = 'a';
             $oauthUser->method('getRaw')->willReturn([
@@ -47,7 +47,7 @@ final class OAuthAuthenticationTest extends TestCase
             return $this->mock_controller($driver)->oauthCallback($request);
         });
 
-        $response = $this->get(__METHOD__);
+        $response = $this->get(__FUNCTION__);
         $response->assertRedirect('/logged-in');
         $this->assertAuthenticated();
     }
@@ -59,14 +59,14 @@ final class OAuthAuthenticationTest extends TestCase
             //
         })->name('login-oauth-redirect');
 
-        $this->app['router']->get(__METHOD__, function (Request $request) use ($exception) {
+        $this->app['router']->get(__FUNCTION__, function (Request $request) use ($exception) {
             $driver = $this->createStub(AzureDriver::class);
             $driver->method('user')->willThrowException($exception);
 
             return $this->mock_controller($driver)->oauthCallback($request);
         });
 
-        $response = $this->get(__METHOD__);
+        $response = $this->get(__FUNCTION__);
         $response->assertRedirect('/login-oauth-redirect');
     }
 
@@ -85,33 +85,33 @@ final class OAuthAuthenticationTest extends TestCase
             //
         })->name('login-oauth-redirect');
 
-        $this->app['router']->get(__METHOD__, function (Request $request) use ($exception) {
+        $this->app['router']->get(__FUNCTION__, function (Request $request) use ($exception) {
             $driver = $this->createStub(AzureDriver::class);
             $driver->method('user')->willThrowException($exception);
 
             return $this->mock_controller($driver)->oauthCallback($request);
         });
 
-        $response = $this->get(__METHOD__);
+        $response = $this->get(__FUNCTION__);
         $response->assertRedirect('/login-oauth-redirect');
     }
 
     public function test_unhandled_exceptions_are_rethrown(): void
     {
-        $this->app['router']->get(__METHOD__, function (Request $request) {
+        $this->app['router']->get(__FUNCTION__, function (Request $request) {
             $driver = $this->createStub(AzureDriver::class);
             $driver->method('user')->willThrowException(new \Exception('Unhandled, yay!'));
 
             return $this->mock_controller($driver)->oauthCallback($request);
         });
 
-        $response = $this->get(__METHOD__);
+        $response = $this->get(__FUNCTION__);
         $this->assertEquals('Unhandled, yay!', $response->exception->getMessage());
     }
 
     public function test_logout(): void
     {
-        $this->app['router']->post(__METHOD__, function (Request $request) {
+        $this->app['router']->post(__FUNCTION__, function (Request $request) {
             $driver = $this->createStub(AzureDriver::class);
             $driver->method('getLogoutUrl')->willReturn('/oauth2/v2.0/logout');
 
@@ -119,14 +119,14 @@ final class OAuthAuthenticationTest extends TestCase
         });
 
         Auth::shouldReceive('logout')->once();
-        $response = $this->post(__METHOD__);
+        $response = $this->post(__FUNCTION__);
         $response->assertRedirect();
         $this->assertStringContainsString('/oauth2/v2.0/logout', $response->headers->get('Location'));
     }
 
     public function test_logout_with_redirect(): void
     {
-        $this->app['router']->post(__METHOD__, function (Request $request) {
+        $this->app['router']->post(__FUNCTION__, function (Request $request) {
             $driver = $this->createStub(AzureDriver::class);
             $driver->method('getLogoutUrl')->willReturn('/oauth2/v2.0/logout');
 
@@ -134,7 +134,7 @@ final class OAuthAuthenticationTest extends TestCase
         });
 
         Auth::shouldReceive('logout')->once();
-        $response = $this->post(__METHOD__);
+        $response = $this->post(__FUNCTION__);
         $response->assertRedirect();
         $this->assertStringContainsString('/oauth2/v2.0/logout', $response->headers->get('Location'));
         $this->assertStringContainsString('?post_logout_redirect_uri=https%3A%2F%2Fgoogle.com%3Ffoo%3D1%26bar%3D2', $response->headers->get('Location'));

--- a/tests/Feature/Auth/OpenAM11AuthenticationTest.php
+++ b/tests/Feature/Auth/OpenAM11AuthenticationTest.php
@@ -51,7 +51,7 @@ final class OpenAM11AuthenticationTest extends TestCase
 
     public function test_successful_login_no_mfa(): void
     {
-        $this->app['router']->get(__METHOD__, function (Request $request) {
+        $this->app['router']->get(__FUNCTION__, function (Request $request) {
             // Doing withCookie() on the get won't work cuz that only injects into the Request,
             // but the controller must access this via the $_COOKIE array to avoid Laravel "decrypting"
             // the value and exploding.
@@ -63,26 +63,26 @@ final class OpenAM11AuthenticationTest extends TestCase
             return $this->mock_controller()->login($request, $this->strategy);
         })->name('login');
 
-        $response = $this->get(__METHOD__);
+        $response = $this->get(__FUNCTION__);
         $response->assertRedirect('/logged-in');
         $this->assertAuthenticated();
     }
 
     public function test_redirects_when_no_cookie(): void
     {
-        $this->app['router']->get(__METHOD__, function (Request $request) {
+        $this->app['router']->get(__FUNCTION__, function (Request $request) {
             unset($_COOKIE['nusso']);
 
             return $this->mock_controller()->login($request, $this->strategy);
         })->name('login');
 
-        $response = $this->get(__METHOD__)->assertRedirect();
+        $response = $this->get(__FUNCTION__)->assertRedirect();
         $this->assertSsoRedirect($response);
     }
 
     public function test_redirects_when_cookie_is_invalid(): void
     {
-        $this->app['router']->get(__METHOD__, function (Request $request) {
+        $this->app['router']->get(__FUNCTION__, function (Request $request) {
             $_COOKIE['nusso'] = 'dummy-token';
 
             $this->api->setHttpClient($this->mockedResponse(407, ''));
@@ -90,13 +90,13 @@ final class OpenAM11AuthenticationTest extends TestCase
             return $this->mock_controller()->login($request, $this->strategy);
         })->name('login');
 
-        $response = $this->get(__METHOD__)->assertRedirect();
+        $response = $this->get(__FUNCTION__)->assertRedirect();
         $this->assertSsoRedirect($response);
     }
 
     public function test_exception_when_apigee_key_is_invalid(): void
     {
-        $this->app['router']->get(__METHOD__, function (Request $request) {
+        $this->app['router']->get(__FUNCTION__, function (Request $request) {
             $_COOKIE['nusso'] = 'dummy-token';
 
             $this->api->setHttpClient($this->mockedResponse(401, ''));
@@ -104,7 +104,7 @@ final class OpenAM11AuthenticationTest extends TestCase
             return $this->mock_controller()->login($request, $this->strategy);
         })->name('login');
 
-        $this->get(__METHOD__)->assertStatus(500);
+        $this->get(__FUNCTION__)->assertStatus(500);
     }
 
     public function test_sends_to_mfa(): void
@@ -115,14 +115,14 @@ final class OpenAM11AuthenticationTest extends TestCase
         $this->api = new ApigeeAgentless(resolve(Client::class), config('app.url'), config('nusoa.sso'));
         $this->strategy = new OpenAM11($this->api);
 
-        $this->app['router']->get(__METHOD__, ['middleware' => 'web', 'uses' => function (Request $request) {
+        $this->app['router']->get(__FUNCTION__, ['middleware' => 'web', 'uses' => function (Request $request) {
             $_COOKIE['openAMssoToken'] = 'dummy-token';
             $this->api->setHttpClient($this->mockedResponse(200, $this->ssoResponseJson('test-id', false)));
 
             return $this->mock_controller()->login($request, $this->strategy);
         }])->name('login');
 
-        $response = $this->withSession([])->get(__METHOD__)->assertRedirect();
+        $response = $this->withSession([])->get(__FUNCTION__)->assertRedirect();
 
         $error = sprintf('SSO redirect URL %s should contain ldap-and-duo', $response->getTargetUrl());
         $this->assertGreaterThan(-1, strpos($response->getTargetUrl(), 'authIndexValue=ldap-and-duo'), $error);
@@ -133,7 +133,7 @@ final class OpenAM11AuthenticationTest extends TestCase
         // Disable the "force HTTPS" thing in ::prepareUrlForRequest
         $this->useSecure = false;
 
-        $this->app['router']->get(__METHOD__, function (Request $request) {
+        $this->app['router']->get(__FUNCTION__, function (Request $request) {
             $_COOKIE['nusso'] = 'dummy-token';
 
             $this->api->setHttpClient($this->mockedResponse(407, ''));
@@ -141,7 +141,7 @@ final class OpenAM11AuthenticationTest extends TestCase
             return $this->mock_controller()->login($request, $this->strategy);
         })->name('login');
 
-        $response = $this->get(__METHOD__)->assertStatus(500);
+        $response = $this->get(__FUNCTION__)->assertStatus(500);
         $this->assertInstanceOf(InsecureSsoError::class, $response->exception);
     }
 

--- a/tests/Feature/VerifyEventHubHMACTest.php
+++ b/tests/Feature/VerifyEventHubHMACTest.php
@@ -29,33 +29,33 @@ final class VerifyEventHubHMACTest extends BaseTestCase
     public function test_valid_signature_pass_through(): void
     {
         $success_msg = 'hmac is ok';
-        $this->app['router']->post(__METHOD__, ['middleware' => self::HMAC_VERIFICATION_MIDDLEWARE, 'uses' => function () use ($success_msg) {
+        $this->app['router']->post(__FUNCTION__, ['middleware' => self::HMAC_VERIFICATION_MIDDLEWARE, 'uses' => function () use ($success_msg) {
             return $success_msg;
         }]);
 
-        $response = $this->postJson(__METHOD__, ['application_id' => 12345], [$this->header_name => '8ZTNZ1zD67n4v2A5ajcoYOTvy3xXi463bes8IiuskCs=']);
+        $response = $this->postJson(__FUNCTION__, ['application_id' => 12345], [$this->header_name => '8ZTNZ1zD67n4v2A5ajcoYOTvy3xXi463bes8IiuskCs=']);
         $response->assertOk();
         $response->assertSeeText($success_msg);
     } // end test_valid_signature_pass_through
 
     public function test_invalid_signature_401_unauthorized(): void
     {
-        $this->app['router']->post(__METHOD__, ['middleware' => self::HMAC_VERIFICATION_MIDDLEWARE, 'uses' => function () {
+        $this->app['router']->post(__FUNCTION__, ['middleware' => self::HMAC_VERIFICATION_MIDDLEWARE, 'uses' => function () {
             return 'middleware passed';
         }]);
 
-        $response = $this->postJson(__METHOD__, ['application_id' => 12345], [$this->header_name => 'lhG3Qp8AjwJ77P4qd5VRN9DxHCRjUCRxCRMrK8BACds=']);
+        $response = $this->postJson(__FUNCTION__, ['application_id' => 12345], [$this->header_name => 'lhG3Qp8AjwJ77P4qd5VRN9DxHCRjUCRxCRMrK8BACds=']);
         $response->assertStatus(401);
         $response->assertSeeText('HMAC Validation Failure');
     } // end test_invalid_signature_401_unauthorized
 
     public function test_no_header_401_unauthorized(): void
     {
-        $this->app['router']->post(__METHOD__, ['middleware' => self::HMAC_VERIFICATION_MIDDLEWARE, 'uses' => function () {
+        $this->app['router']->post(__FUNCTION__, ['middleware' => self::HMAC_VERIFICATION_MIDDLEWARE, 'uses' => function () {
             return 'middleware passed';
         }]);
 
-        $response = $this->postJson(__METHOD__, ['application_id' => 12345]);
+        $response = $this->postJson(__FUNCTION__, ['application_id' => 12345]);
         $response->assertStatus(401);
         $response->assertSeeText('No HMAC Signature Sent');
     } // end test_no_header_401_unauthorized
@@ -64,11 +64,11 @@ final class VerifyEventHubHMACTest extends BaseTestCase
     {
         $this->app['config']->set('nusoa.eventHub.hmacVerificationAlgorithmForPHPHashHmac', 'a very invalid algorithm');
 
-        $this->app['router']->post(__METHOD__, ['middleware' => self::HMAC_VERIFICATION_MIDDLEWARE, 'uses' => function () {
+        $this->app['router']->post(__FUNCTION__, ['middleware' => self::HMAC_VERIFICATION_MIDDLEWARE, 'uses' => function () {
             return 'middleware passed';
         }]);
 
-        $response = $this->postJson(__METHOD__, ['application_id' => 12345], [$this->header_name => '8ZTNZ1zD67n4v2A5ajcoYOTvy3xXi463bes8IiuskCs=']);
+        $response = $this->postJson(__FUNCTION__, ['application_id' => 12345], [$this->header_name => '8ZTNZ1zD67n4v2A5ajcoYOTvy3xXi463bes8IiuskCs=']);
         $response->assertStatus(500);
         $response->assertSeeText('Invalid hash algorithm');
     } // end test_bad_hmac_algorithm


### PR DESCRIPTION
The impact seems to be limited to tests. Using `__METHOD__` for the routes being tested is resulting in an error now:

```
Symfony\Component\HttpFoundation\Exception\BadRequestException: Invalid URI: A URI cannot contain a backslash.
```

Not sure if this is a PHP 8.4 change or a Symfony change, but fair enough. `__FUNCTION__` returns just the method name, which should be sufficient.