### PR TITLE
Add `eventHubWebhookActiveWhen()` for conditional webhook activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `laravel/prompts` as a dependency for improved CLI interactions.
 - EventHub webhook commands now prompt for confirmation when run in local environments.
+- Added `eventHubWebhookActiveWhen()` route macro for conditional webhook activation. These webhooks are still registered, but start paused when the condition is `false`.
 
 ### Changed
 - All EventHub Artisan commands have been modernized with improved output formatting using Laravel Prompts.

--- a/docs/eventhub.md
+++ b/docs/eventhub.md
@@ -49,6 +49,9 @@ This package makes receiving webhooks easy: register a queue name to a route, ap
 Route::post('events/netid-update', 'NetIdUpdateController')->eventHubWebhook('my-team.ldap.netid.term');
 Route::post('events/employee-update', 'EmployeeUpdateController')->eventHubWebhook('my-team.employee.updates', ['contentType' => 'application/xml']); // for XML messages
 
+// Register a webhook that starts paused (e.g., only active in production)
+Route::post('events/prod-only', 'ProdOnlyController')->eventHubWebhookActiveWhen(App::isProduction(), 'my-team.prod.events');
+
 // App\Http\Controllers\NetIdUpdateController
 use Illuminate\Http\Request;
 
@@ -86,6 +89,22 @@ php artisan eventhub:webhook:toggle unpause
 
 EventHub will retry failed message deliveries for time time if you have forgotten to pause. See the EventHub documentation for more information on delivery re-tries.
 :::
+
+### Conditional Webhook Registration
+
+Use `eventHubWebhookActiveWhen()` to register webhooks that should only be active by default under a certain condition:
+
+```php
+Route::post('events/prod-only', 'ProdOnlyController')
+    ->eventHubWebhookActiveWhen(App::isProduction(), 'my-team.prod.events');
+```
+
+When the condition is `false`, the webhook is still registered in EventHub but starts in a **paused** state. This is useful when:
+
+- You want to test webhook delivery on-demand by temporarily unpausing, then re-pausing after
+- You have environment-specific webhooks that lower environments simply don't need active
+
+On each deployment, running `eventhub:webhook:configure` will enforce the active state based on your route configuration so that webhooks return to their intended state.
 
 ## EventHub Artisan Commands
 The following artisan commands will be available when you install this package.

--- a/src/Console/Commands/EventHub/WebhookConfiguration.php
+++ b/src/Console/Commands/EventHub/WebhookConfiguration.php
@@ -87,10 +87,12 @@ class WebhookConfiguration extends Command
         $topicName = $hook['topicName'];
 
         try {
-            // If the hook exists on EventHub already, we don't need to touch the 'active' status.
-            // But, new ones will require it.
             if (in_array($hook['topicName'], $registered_hooks) === false) {
-                $hook['active'] = true;
+                // For new webhooks, use the active state from the
+                // DTO if set, otherwise default to true.
+                if (! array_key_exists('active', $hook)) {
+                    $hook['active'] = true;
+                }
 
                 // Not allowed in the POST/PUT body
                 unset($hook['topicName']);
@@ -102,6 +104,9 @@ class WebhookConfiguration extends Command
 
                 $this->components->info("Created webhook for <bg=magenta;fg=white;options=bold> {$topicName} </>");
             } else {
+                // For existing webhooks, enforce the active state if specified.
+                // This allows `eventHubWebhookActiveWhen()` to control state.
+
                 // Not allowed in the POST/PUT body
                 unset($hook['topicName']);
 

--- a/src/Providers/NuSoaServiceProvider.php
+++ b/src/Providers/NuSoaServiceProvider.php
@@ -126,12 +126,43 @@ class NuSoaServiceProvider extends ServiceProvider
             return new EventHubWebhookRegistration;
         });
 
+        /**
+         * Register an EventHub webhook for this route.
+         *
+         * @param string $queue The EventHub queue name
+         * @param array $additional_settings Optional webhook configuration overrides
+         */
         Route::macro('eventHubWebhook', function ($queue, $additional_settings = []) {
             /** @var Route $this */
             $url = url($this->uri());
 
             $registry = resolve(EventHubWebhookRegistration::class);
             $registry->registerHookToRoute($queue, $url, $additional_settings);
+
+            return $this;
+        });
+
+        /**
+         * Register an EventHub webhook with conditional activation.
+         *
+         * The webhook is always registered, but the condition determines its active state.
+         * When false, the webhook starts paused, which is useful for production-only
+         * webhooks or safe testing scenarios.
+         *
+         * Running `eventhub:webhook:configure` enforces this state on execution by
+         * automatically pausing webhooks that may have been manually unpaused for
+         * testing purposes.
+         *
+         * @param bool $condition When true, webhook is active; when false, webhook is paused
+         * @param string $queue The EventHub queue name
+         * @param array $additional_settings Optional webhook configuration overrides
+         */
+        Route::macro('eventHubWebhookActiveWhen', function (bool $condition, string $queue, array $additional_settings = []) {
+            /** @var Route $this */
+            $url = url($this->uri());
+
+            $registry = resolve(EventHubWebhookRegistration::class);
+            $registry->registerHookToRoute($queue, $url, $additional_settings, active: $condition);
 
             return $this;
         });

--- a/src/Routing/EventHubWebhookRegistration.php
+++ b/src/Routing/EventHubWebhookRegistration.php
@@ -23,7 +23,7 @@ class EventHubWebhookRegistration
         $this->use_hmac = $this->hmac_secret !== null;
     }
 
-    public function registerHookToRoute($queue, $url, $additional_settings = []): void
+    public function registerHookToRoute($queue, $url, $additional_settings = [], ?bool $active = null): void
     {
         $hook = new Webhook($queue, $url);
 
@@ -32,6 +32,10 @@ class EventHubWebhookRegistration
         }
 
         $hook->setAdditionalSettings($additional_settings);
+
+        if ($active !== null) {
+            $hook->setActive($active);
+        }
 
         $this->hooks[] = $hook;
     }

--- a/src/Routing/Webhook.php
+++ b/src/Routing/Webhook.php
@@ -16,6 +16,8 @@ class Webhook
 
     protected $additional_settings = [];
 
+    protected ?bool $active = null;
+
     public function __construct(string $queue, string $delivery_url)
     {
         $this->queue = $queue;
@@ -33,6 +35,11 @@ class Webhook
     {
         $this->additional_settings = array_merge_recursive($this->additional_settings, $settings);
     } // end setAdditionalSettings
+
+    public function setActive(bool $active)
+    {
+        $this->active = $active;
+    }
 
     public function toArray()
     {
@@ -54,8 +61,11 @@ class Webhook
             'contentType' => 'application/json',
             'securityTypes' => [],
             'webhookSecurity' => [],
-            // 'active' => true,
         ], $default_settings);
+
+        if ($this->active !== null) {
+            $final_settings['active'] = $this->active;
+        }
 
         // Additive instead of replacing
         if (array_key_exists('securityTypes', $additional_settings) === true) {

--- a/tests/Feature/WebhookRouteRegistrationTest.php
+++ b/tests/Feature/WebhookRouteRegistrationTest.php
@@ -79,6 +79,50 @@ final class WebhookRouteRegistrationTest extends BaseTestCase
         $this->assertEquals($content_type, $hook['contentType']);
     } // end test_change_content_type
 
+    public function test_conditional_registration_with_true_sets_active(): void
+    {
+        app()->router->post('/webhook/conditional')->eventHubWebhookActiveWhen(true, 'conditional.queue');
+
+        $registered_hooks = resolve(EventHubWebhookRegistration::class)->getHooks();
+        $this->assertCount(1, $registered_hooks);
+
+        $hook = $registered_hooks[0]->toArray();
+        $this->assertTrue($hook['active']);
+    }
+
+    public function test_conditional_registration_with_false_sets_inactive(): void
+    {
+        app()->router->post('/webhook/conditional')->eventHubWebhookActiveWhen(false, 'conditional.queue');
+
+        $registered_hooks = resolve(EventHubWebhookRegistration::class)->getHooks();
+        $this->assertCount(1, $registered_hooks);
+
+        $hook = $registered_hooks[0]->toArray();
+        $this->assertFalse($hook['active']);
+    }
+
+    public function test_conditional_registration_preserves_additional_settings(): void
+    {
+        $content_type = 'application/xml';
+        app()->router->post('/webhook/conditional')->eventHubWebhookActiveWhen(false, 'conditional.queue', ['contentType' => $content_type]);
+
+        $registered_hooks = resolve(EventHubWebhookRegistration::class)->getHooks();
+        $hook = $registered_hooks[0]->toArray();
+
+        $this->assertFalse($hook['active']);
+        $this->assertEquals($content_type, $hook['contentType']);
+    }
+
+    public function test_regular_webhook_does_not_set_active_state(): void
+    {
+        app()->router->post('/webhook/foo')->eventHubWebhook('foo.my-queue');
+
+        $registered_hooks = resolve(EventHubWebhookRegistration::class)->getHooks();
+        $hook = $registered_hooks[0]->toArray();
+
+        $this->assertArrayNotHasKey('active', $hook);
+    }
+
     protected function makeApiSecurityBlock($secret)
     {
         return [


### PR DESCRIPTION
Adds a new route macro for registering EventHub webhooks with conditional activation:

```php
Route::post('events/prod-only', 'ProdOnlyController')
    ->eventHubWebhookActiveWhen(App::isProduction(), 'my-team.prod.events');
```

Unlike the existing `eventHubWebhook()` macro, this registers the webhook in EventHub but uses the condition to control its active state. When the condition is `false`, the webhook starts paused.

This is useful when:
- You have production-only webhooks that lower environments don't need active
- You want the option to manually unpause for testing, then have it re-pause on the next deployment

Running `eventhub:webhook:configure` enforces the configured state, so any webhooks manually unpaused for testing will automatically return to their intended state.