### PR TITLE
feat: Laravel 13 compatibility

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,10 +14,10 @@ jobs:
         node-version: [24.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v3
+      uses: pnpm/action-setup@v5
       with:
         version: 10.x.x
 
@@ -35,7 +35,7 @@ jobs:
         pnpm build
 
     - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4.5.0
+      uses: JamesIves/github-pages-deploy-action@v4.8.0
       with:
         branch: gh-pages
         folder: docs/dist

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -16,7 +16,7 @@ jobs:
         php-versions: ['8.3', '8.4', '8.5']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.3', '8.4', '8.5']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -14,10 +14,10 @@ jobs:
         node-version: [24.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v3
+      uses: pnpm/action-setup@v5
       with:
         version: 10.x.x
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped support for PHP 8.2. The minimum required version is now PHP 8.3.
 - Support for Laravel 13 has been added.
 - Dropped support for Guzzle 6. The minimum required version is now Guzzle 7.
-- Dropped support for `laravel/ui` v2 and v3. The minimum required version is now v4.6.3.
+- Dropped support for `laravel/ui` v2 and v3. The minimum required version is now v4.
 - Widened `socialiteproviders/manager` constraint from `~4.8.1` to `^4.8.1`.
 - Replaced deprecated `Closure::fromCallable('static::...')` callables with first-class callable syntax for PHP 8.5 compatibility.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ## [v12.0.0] - 2026-04-10
+### Fixed
+- `WebSSOAuthentication` trait now regenerates the session after login and invalidates it on logout to prevent session fixation attacks.
+
 ### Changed
 - Dropped support for PHP 8.2. The minimum required version is now PHP 8.3.
 - Support for Laravel 13 has been added.
 - Dropped support for Guzzle 6. The minimum required version is now Guzzle 7.
 - Dropped support for `laravel/ui` v2 and v3. The minimum required version is now v4.6.3.
 - Widened `socialiteproviders/manager` constraint from `~4.8.1` to `^4.8.1`.
+- Replaced deprecated `Closure::fromCallable('static::...')` callables with first-class callable syntax for PHP 8.5 compatibility.
 
 ## [v11.4.0] - 2026-03-11
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [v12.0.0] - 2026-04-10
+### Changed
+- Dropped support for PHP 8.2. The minimum required version is now PHP 8.3.
+- Support for Laravel 13 has been added.
+- Dropped support for Guzzle 6. The minimum required version is now Guzzle 7.8.2.
+- Dropped support for `laravel/ui` v2 and v3. The minimum required version is now v4.6.3.
+- Widened `socialiteproviders/manager` constraint from `~4.8.1` to `^4.8.1`.
+
 ## [v11.4.0] - 2026-03-11
 ### Changed
 - Bumped minimum `firebase/jwt` and `lcobucci/jwt` versions used by the Entra ID SSO code. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Dropped support for PHP 8.2. The minimum required version is now PHP 8.3.
 - Support for Laravel 13 has been added.
-- Dropped support for Guzzle 6. The minimum required version is now Guzzle 7.8.2.
+- Dropped support for Guzzle 6. The minimum required version is now Guzzle 7.
 - Dropped support for `laravel/ui` v2 and v3. The minimum required version is now v4.6.3.
 - Widened `socialiteproviders/manager` constraint from `~4.8.1` to `^4.8.1`.
 

--- a/composer.json
+++ b/composer.json
@@ -15,21 +15,21 @@
         }
     ],
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "ext-openssl": "*",
-        "guzzlehttp/guzzle": "^7.0|^6.0",
+        "guzzlehttp/guzzle": "^7.8.2",
         "northwestern-sysdev/event-hub-php-sdk": "^3.0",
-        "laravel/ui": "^3.0|^2.0|^4.0",
+        "laravel/ui": "^4.6.3",
         "lcobucci/jwt": "^5.0",
         "lcobucci/clock": "^2|^3",
-        "socialiteproviders/manager": "~4.8.1",
+        "socialiteproviders/manager": "^4.8.1",
         "firebase/php-jwt": "^7",
         "laravel/prompts": "^0.3.10"
     },
     "require-dev": {
-        "orchestra/testbench": "^10.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "php-coveralls/php-coveralls": "^2.4",
-        "phpunit/phpunit": "^11.0",
+        "phpunit/phpunit": "^11.5.50|^12.0",
         "laravel/pint": "^1.13",
         "larastan/larastan": "^3.0",
         "spatie/invade": "^2.1"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=8.3",
         "ext-openssl": "*",
-        "guzzlehttp/guzzle": "^7.8.2",
+        "guzzlehttp/guzzle": "^7.0",
         "northwestern-sysdev/event-hub-php-sdk": "^3.0",
         "laravel/ui": "^4.6.3",
         "lcobucci/jwt": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-openssl": "*",
         "guzzlehttp/guzzle": "^7.0",
         "northwestern-sysdev/event-hub-php-sdk": "^3.0",
-        "laravel/ui": "^4.6.3",
+        "laravel/ui": "^4.0",
         "lcobucci/jwt": "^5.0",
         "lcobucci/clock": "^2|^3",
         "socialiteproviders/manager": "^4.8.1",

--- a/docs/src/content/docs/upgrading.md
+++ b/docs/src/content/docs/upgrading.md
@@ -11,7 +11,7 @@ v12 adds support for Laravel 13 and drops support for PHP 8.2. The minimum PHP v
 
 ### Dependency Changes
 - Guzzle 6 is no longer supported. If your application still depends on Guzzle 6, you must upgrade to Guzzle 7+.
-- `laravel/ui` v2 and v3 are no longer supported. Upgrade to v4.6.3+.
+- `laravel/ui` v2 and v3 are no longer supported. Upgrade to v4+.
 
 ## From v10 to v11
 When upgrading to Laravel 11 from a previous version, if you have applied the Laravel skeleton simplifications, you will need to update the Azure AD callback route when deleting the `\App\Http\Middleware\VerifyCsrfToken`:

--- a/docs/src/content/docs/upgrading.md
+++ b/docs/src/content/docs/upgrading.md
@@ -10,7 +10,7 @@ sidebar:
 v12 adds support for Laravel 13 and drops support for PHP 8.2. The minimum PHP version is now 8.3.
 
 ### Dependency Changes
-- Guzzle 6 is no longer supported. If your application still depends on Guzzle 6, you must upgrade to Guzzle 7.8.2+.
+- Guzzle 6 is no longer supported. If your application still depends on Guzzle 6, you must upgrade to Guzzle 7+.
 - `laravel/ui` v2 and v3 are no longer supported. Upgrade to v4.6.3+.
 
 ## From v10 to v11

--- a/docs/src/content/docs/upgrading.md
+++ b/docs/src/content/docs/upgrading.md
@@ -6,6 +6,13 @@ sidebar:
 ---
 
 
+## From v11 to v12
+v12 adds support for Laravel 13 and drops support for PHP 8.2. The minimum PHP version is now 8.3.
+
+### Dependency Changes
+- Guzzle 6 is no longer supported. If your application still depends on Guzzle 6, you must upgrade to Guzzle 7.8.2+.
+- `laravel/ui` v2 and v3 are no longer supported. Upgrade to v4.6.3+.
+
 ## From v10 to v11
 When upgrading to Laravel 11 from a previous version, if you have applied the Laravel skeleton simplifications, you will need to update the Azure AD callback route when deleting the `\App\Http\Middleware\VerifyCsrfToken`:
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Test Suite">
       <directory suffix=".php">./tests/Feature</directory>

--- a/src/Auth/WebSSOAuthentication.php
+++ b/src/Auth/WebSSOAuthentication.php
@@ -74,7 +74,7 @@ trait WebSSOAuthentication
     }
 
     /**
-     * Azure AD OAuth initiator action
+     * Entra ID OAuth initiator action.
      */
     public function oauthRedirect()
     {
@@ -82,7 +82,7 @@ trait WebSSOAuthentication
     }
 
     /**
-     * OAuth callback URL, where users are sent after authenticating with Azure.
+     * OAuth callback URL, where users are sent after authenticating with Entra ID.
      */
     public function oauthCallback(Request $request)
     {
@@ -132,7 +132,7 @@ trait WebSSOAuthentication
      * of doing anything on its own. This is for backwards-compatibility -- if you've used
      * OpenAM SSO in the past (or plan to in the future), the two methods can be used interchangably.
      *
-     * In cases where you wish to utilize data from the Azure AD profile (like email, name, phone, etc),
+     * In cases where you wish to utilize data from the Entra ID profile (like email, name, phone, etc),
      * you can implement this method and return a Laravel user directly, without invoking the
      * ::findUserByNetID method.
      */

--- a/src/Auth/WebSSOAuthentication.php
+++ b/src/Auth/WebSSOAuthentication.php
@@ -9,6 +9,7 @@ use Illuminate\Foundation\Auth\RedirectsUsers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\InvalidStateException;
@@ -36,10 +37,11 @@ trait WebSSOAuthentication
             return redirect($e->getRedirectUrl());
         }
 
-        $user = app()->call(\Closure::fromCallable('static::findUserByNetId'), ['netid' => $netid]);
+        $user = app()->call(static::findUserByNetID(...), ['netid' => $netid]);
         throw_if($user === null, new AuthenticationException());
 
         Auth::login($user);
+        Session::regenerate();
 
         return $this->authenticated($request, $user) ?: redirect()->intended($this->redirectPath());
     }
@@ -50,6 +52,8 @@ trait WebSSOAuthentication
     public function logout(WebSSOStrategy $sso_strategy)
     {
         Auth::logout();
+        Session::invalidate();
+        Session::regenerateToken();
 
         return $sso_strategy->logout($this->logout_return_to_route);
     }
@@ -57,6 +61,8 @@ trait WebSSOAuthentication
     public function oauthLogout($postLogoutRedirectUri = null)
     {
         Auth::logout();
+        Session::invalidate();
+        Session::regenerateToken();
 
         if ($postLogoutRedirectUri != null) {
             $url = $this->oauthDriver()->getLogoutUrl().'?post_logout_redirect_uri='.urlencode($postLogoutRedirectUri);
@@ -76,7 +82,7 @@ trait WebSSOAuthentication
     }
 
     /**
-     * OAuth callback URL, where users are sent when they're
+     * OAuth callback URL, where users are sent after authenticating with Azure.
      */
     public function oauthCallback(Request $request)
     {
@@ -108,12 +114,13 @@ trait WebSSOAuthentication
         );
 
         $user = app()->call(
-            \Closure::fromCallable('static::findUserByOAuthUser'),
+            static::findUserByOAuthUser(...),
             ['oauthUser' => $oauthUser]
         );
         throw_if($user === null, new AuthenticationException());
 
         Auth::login($user);
+        Session::regenerate();
 
         return $this->authenticated($request, $user) ?: redirect()->intended($this->redirectPath());
     }
@@ -132,7 +139,7 @@ trait WebSSOAuthentication
     protected function findUserByOAuthUser(OAuthUser $oauthUser): ?Authenticatable
     {
         return app()->call(
-            \Closure::fromCallable('static::findUserByNetID'),
+            static::findUserByNetID(...),
             ['netid' => $oauthUser->getNetid()]
         );
     }

--- a/stubs/WebSSOController.stub
+++ b/stubs/WebSSOController.stub
@@ -25,8 +25,8 @@ class WebSSOController extends Controller
     /*
     protected function findUserByOAuthUser(OAuthUser $oauthUser): ?Authenticatable
     {
-        // Called when using Azure AD OAuth login.
-        // This method has access to the whole user returned by Azure AD.
+        // Called when using Entra ID OAuth login.
+        // This method has access to the whole user returned by Entra ID.
 
         // You can use this instead of ::findUserByNetID, which only has access to a netID.
 


### PR DESCRIPTION
## Summary
- Bump minimum PHP from 8.2 to 8.3 (Laravel 13 requirement)
- Add Laravel 13 / Testbench 11 / PHPUnit 12 support
- Drop Guzzle 6 support (require ^7.0)
- Drop `laravel/ui` v2 and v3 (require ^4.0)
- Widen `socialiteproviders/manager` constraint to `^4.8.1`
- Fix session fixation: regenerate session on login, invalidate on logout
- Replace deprecated `Closure::fromCallable('static::...')` with first-class callable syntax (PHP 8.5)
- Bump GitHub Actions: `actions/checkout` v6, `pnpm/action-setup` v5, `github-pages-deploy-action` v4.8.0
- Drop PHP 8.2 from CI matrix

## Supersedes
Closes #192 (actions/checkout v6)
Closes #190 (pnpm/action-setup v5)
Closes #191 (github-pages-deploy-action v4.8.0)
Closes #193 (socialiteproviders/manager widening)